### PR TITLE
Use a Spec FIFO to only update correctly speculated predictions

### DIFF
--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -63,6 +63,7 @@ import ReorderBuffer::*;
 import ReorderBufferSynth::*;
 import Scoreboard::*;
 import ScoreboardSynth::*;
+import SpecFifo::*;
 import SpecTagManager::*;
 import Fpu::*;
 import MulDiv::*;
@@ -84,6 +85,7 @@ import MMIOCore::*;
 import RenameStage::*;
 import CommitStage::*;
 import Bypass::*;
+import DirPredictor::*;
 
 import CsrFile :: *;
 
@@ -305,11 +307,18 @@ module mkCore#(CoreId coreId)(Core);
         for(Integer i = 0; i < valueof(FpuMulDivExeNum); i = i+1) begin
             fpuMulDivSpecUpdate[i] = fix.fpuMulDivExeIfc[i].specUpdate;
         end
+
+        Vector#(AluExeNum, SpecFifo#(`NUM_SPEC_TAGS, FetchTrainBP, 1, 1)) trainBPQ <- replicateM(mkSpecFifoUG(True));
+        Vector#(AluExeNum, SpeculationUpdate) btqSpecUpdate;
+        for(Integer i = 0; i < valueof(AluExeNum); i = i+1) begin
+            btqSpecUpdate[i] = trainBPQ[i].specUpdate;
+        end
+        
         GlobalSpecUpdate#(CorrectSpecPortNum, ConflictWrongSpecPortNum) globalSpecUpdate <- mkGlobalSpecUpdate(
             joinSpeculationUpdate(
-                append(append(vec(regRenamingTable.specUpdate,
+                append(append(append(vec(regRenamingTable.specUpdate,
                                   specTagManager.specUpdate,
-                                  fix.memExeIfc.specUpdate), aluSpecUpdate), fpuMulDivSpecUpdate)
+                                  fix.memExeIfc.specUpdate), aluSpecUpdate), fpuMulDivSpecUpdate), btqSpecUpdate)
             ),
             rob.specUpdate
         );
@@ -339,7 +348,7 @@ module mkCore#(CoreId coreId)(Core);
         endaction
         endfunction
 
-        Vector#(AluExeNum, FIFO#(FetchTrainBP)) trainBPQ <- replicateM(mkFIFO);
+     
         Vector#(AluExeNum, AluExePipeline) aluExe;
         for(Integer i = 0; i < valueof(AluExeNum); i = i+1) begin
             Vector#(2, SendBypass) sendBypassIfc; // exe and finish
@@ -367,7 +376,10 @@ module mkCore#(CoreId coreId)(Core);
                 method rob_getPredPC = rob.getOrigPredPC[i].get;
                 method rob_getOrig_Inst = rob.getOrig_Inst[i].get;
                 method rob_setExecuted = rob.setExecuted_doFinishAlu[i].set;
-                method fetch_train_predictors = toPut(trainBPQ[i]).put;
+                method fetch_train_predictors = trainBPQ[i].enq;
+                method Action fetch_recover_spec(DirPredSpecInfo specInfo, Bool taken); 
+                    fetchStage.recover_spec(specInfo, taken);
+                endmethod
                 method setRegReadyAggr = writeAggr(aluWrAggrPort(i));
                 interface sendBypass = sendBypassIfc;
                 method writeRegFile = writeCons(aluWrConsPort(i));
@@ -385,9 +397,13 @@ module mkCore#(CoreId coreId)(Core);
                 method doStats = doStatsReg._read;
             endinterface);
             aluExe[i] <- mkAluExePipeline(aluExeInput);
+            
+            Bool train_ready = (trainBPQ[i].first.spec_bits == 0);
+
             // truly call fetch method to train branch predictor
-            rule doFetchTrainBP;
-                let train <- toGet(trainBPQ[i]).get;
+            rule doFetchTrainBP(trainBPQ[i].notEmpty && train_ready);
+                let train = trainBPQ[i].first.data;
+                trainBPQ[i].deq;
                 fetchStage.train_predictors(
                     train.pc, train.nextPc, train.iType, train.taken,
                     train.dpTrain, train.mispred, train.isCompressed

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -308,7 +308,7 @@ module mkCore#(CoreId coreId)(Core);
             fpuMulDivSpecUpdate[i] = fix.fpuMulDivExeIfc[i].specUpdate;
         end
 
-        Vector#(AluExeNum, SpecFifo#(`NUM_SPEC_TAGS, FetchTrainBP, 1, 1)) trainBPQ <- replicateM(mkSpecFifoUG(True));
+        Vector#(AluExeNum, SpecFifo#(TDiv#(`NUM_SPEC_TAGS,2), FetchTrainBP, 1, 1)) trainBPQ <- replicateM(mkSpecFifoUG(True));
         Vector#(AluExeNum, SpeculationUpdate) btqSpecUpdate;
         for(Integer i = 0; i < valueof(AluExeNum); i = i+1) begin
             btqSpecUpdate[i] = trainBPQ[i].specUpdate;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -343,8 +343,12 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
             inIfc.redirect(x.controlFlow.nextPc, validValue(x.spec_tag), x.tag, exeToFin.spec_bits);
             // must be a branch, train branch predictor
             doAssert(x.iType == Jr || x.iType == Br, "only jr and br can mispredict");
-            
-            inIfc.fetch_recover_spec(x.dpSpec, x.controlFlow.taken);
+
+            if(x.iType == Br) begin
+                inIfc.fetch_recover_spec(x.dpSpec, x.controlFlow.taken);
+            end
+
+            $display("Cycle %d REDIRECT ",  cur_cycle, fshow(x.iType), " %x, SPEC_TAG %b\n", x.controlFlow.pc, validValue(x.spec_tag));
 
             inIfc.fetch_train_predictors(ToSpecFifo{
                 data: FetchTrainBP {

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -348,8 +348,6 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 inIfc.fetch_recover_spec(x.dpSpec, x.controlFlow.taken);
             end
 
-            $display("Cycle %d REDIRECT ",  cur_cycle, fshow(x.iType), " %x, SPEC_TAG %b\n", x.controlFlow.pc, validValue(x.spec_tag));
-
             inIfc.fetch_train_predictors(ToSpecFifo{
                 data: FetchTrainBP {
                     pc: x.controlFlow.pc,

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -54,6 +54,7 @@ typedef struct {
     PhyRegs regs;
     InstTag tag;
     DirPredTrainInfo dpTrain;
+    DirPredSpecInfo dpSpec;
     // specualtion
     Maybe#(SpecTag) spec_tag;
 } AluDispatchToRegRead deriving(Bits, Eq, FShow);
@@ -64,6 +65,7 @@ typedef struct {
     Maybe#(PhyDst) dst;
     InstTag tag;
     DirPredTrainInfo dpTrain;
+    DirPredSpecInfo dpSpec;
     // src reg vals & pc & ppc
     Data rVal1;
     Data rVal2;
@@ -80,6 +82,7 @@ typedef struct {
     Maybe#(PhyDst) dst;
     InstTag tag;
     DirPredTrainInfo dpTrain;
+    DirPredSpecInfo dpSpec;
     Bool isCompressed;
     // result
     Data data; // alu compute result
@@ -143,7 +146,8 @@ interface AluExeInput;
     method Bit #(32) rob_getOrig_Inst (InstTag t);
     method Action rob_setExecuted(InstTag t, Data dst_data, Maybe#(Data) csrData, ControlFlow cf);
     // Fetch stage
-    method Action fetch_train_predictors(FetchTrainBP train);
+    method Action fetch_train_predictors(ToSpecFifo#(FetchTrainBP) train);
+    method Action fetch_recover_spec(DirPredSpecInfo specInfo, Bool taken);
 
     // global broadcast methods
     // set aggressive sb & wake up inst in RS
@@ -210,6 +214,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 regs: x.regs,
                 tag: x.tag,
                 dpTrain: x.data.dpTrain,
+                dpSpec: x.data.dpSpec,
                 spec_tag: x.spec_tag
             },
             spec_bits: x.spec_bits
@@ -252,6 +257,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 dst: x.regs.dst,
                 tag: x.tag,
                 dpTrain: x.dpTrain,
+                dpSpec: x.dpSpec,
                 rVal1: rVal1,
                 rVal2: rVal2,
                 pc: pc,
@@ -296,6 +302,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 dst: x.dst,
                 tag: x.tag,
                 dpTrain: x.dpTrain,
+                dpSpec: x.dpSpec,
                 isCompressed: x.orig_inst[1:0] != 2'b11,
                 data: exec_result.data,
                 csrData: isValid(x.dInst.csr) ? Valid (exec_result.csrData) : Invalid,
@@ -326,6 +333,8 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
             x.controlFlow
         );
 
+        let train_spec_bits = exeToFin.spec_bits;
+
         // handle spec tags for branch predictions
         (* split *)
         if (x.controlFlow.mispredict) (* nosplit *) begin
@@ -334,14 +343,20 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
             inIfc.redirect(x.controlFlow.nextPc, validValue(x.spec_tag), x.tag, exeToFin.spec_bits);
             // must be a branch, train branch predictor
             doAssert(x.iType == Jr || x.iType == Br, "only jr and br can mispredict");
-            inIfc.fetch_train_predictors(FetchTrainBP {
-                pc: x.controlFlow.pc,
-                nextPc: x.controlFlow.nextPc,
-                iType: x.iType,
-                taken: x.controlFlow.taken,
-                dpTrain: x.dpTrain,
-                mispred: True,
-                isCompressed: x.isCompressed
+            
+            inIfc.fetch_recover_spec(x.dpSpec, x.controlFlow.taken);
+
+            inIfc.fetch_train_predictors(ToSpecFifo{
+                data: FetchTrainBP {
+                    pc: x.controlFlow.pc,
+                    nextPc: x.controlFlow.nextPc,
+                    iType: x.iType,
+                    taken: x.controlFlow.taken,
+                    dpTrain: x.dpTrain,
+                    mispred: True,
+                    isCompressed: x.isCompressed
+                },
+                spec_bits: train_spec_bits
             });
             if(verbose) $display("alu mispredict pc¤: %x, nextPc: %x, %d",
                                   x.controlFlow.pc, x.controlFlow.nextPc, cur_cycle);
@@ -365,14 +380,17 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
             // since we can only do 1 training in a cycle, split the rule
             // XXX not training JAL, reduce chance of conflicts
             if(x.iType == Jr || x.iType == Br) begin
-                inIfc.fetch_train_predictors(FetchTrainBP {
-                    pc: x.controlFlow.pc,
-                    nextPc: x.controlFlow.nextPc,
-                    iType: x.iType,
-                    taken: x.controlFlow.taken,
-                    dpTrain: x.dpTrain,
-                    mispred: False,
-                    isCompressed: x.isCompressed
+                inIfc.fetch_train_predictors( ToSpecFifo{
+                    data: FetchTrainBP {
+                        pc: x.controlFlow.pc,
+                        nextPc: x.controlFlow.nextPc,
+                        iType: x.iType,
+                        taken: x.controlFlow.taken,
+                        dpTrain: x.dpTrain,
+                        mispred: False,
+                        isCompressed: x.isCompressed
+                    },
+                    spec_bits: train_spec_bits
                 });
             end
         end

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
@@ -332,6 +332,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
         let ppc = x.ppc;
         let main_epoch = x.main_epoch;
         let dpTrain = x.dpTrain;
+        let dpSpec = x.dpSpec;
         let inst = x.inst;
         let dInst = x.dInst;
         let arch_regs = x.regs;
@@ -457,6 +458,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
         let ppc = x.ppc;
         let main_epoch = x.main_epoch;
         let dpTrain = x.dpTrain;
+        let dpSpec = x.dpSpec;
         let inst = x.inst;
         let dInst = x.dInst;
         let arch_regs = x.regs;
@@ -510,7 +512,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
         // send to ALU reservation station
         if (to_exec) begin
             reservationStationAlu[0].enq(ToReservationStation {
-                data: AluRSData {dInst: dInst, dpTrain: dpTrain},
+                data: AluRSData {dInst: dInst, dpTrain: dpTrain, dpSpec: dpSpec},
                 regs: phy_regs,
                 tag: inst_tag,
                 spec_bits: spec_bits,
@@ -624,6 +626,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
         let ppc = x.ppc;
         let main_epoch = x.main_epoch;
         let dpTrain = x.dpTrain;
+        let dpSpec = x.dpSpec;
         let inst = x.inst;
         let dInst = x.dInst;
         let arch_regs = x.regs;
@@ -836,6 +839,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                 let ppc = x.ppc;
                 let main_epoch = x.main_epoch;
                 let dpTrain = x.dpTrain;
+                let dpSpec = x.dpSpec;
                 let inst = x.inst;
                 let dInst = x.dInst;
                 let arch_regs = x.regs;
@@ -944,7 +948,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                             // can process, send to ALU rs
                             aluExeUsed[k] = True; // mark resource used
                             reservationStationAlu[k].enq(ToReservationStation {
-                                data: AluRSData {dInst: dInst, dpTrain: dpTrain},
+                                data: AluRSData {dInst: dInst, dpTrain: dpTrain, dpSpec: dpSpec},
                                 regs: phy_regs,
                                 tag: inst_tag,
                                 spec_bits: spec_bits,

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/ReservationStationAlu.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/ReservationStationAlu.bsv
@@ -32,6 +32,7 @@ import DirPredictor::*;
 typedef struct {
     DecodedInst dInst;
     DirPredTrainInfo dpTrain;
+    DirPredSpecInfo dpSpec;
 } AluRSData deriving(Bits, Eq, FShow);
 
 // ALU pipeline is aggressive, i.e. it recv bypass and early RS wakeup

--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -56,15 +56,17 @@ function Addr offsetPc(Addr pc, Integer i) = {truncateLSB(pc), pc[7:0] + (fromIn
 typedef struct {
     Bool taken;
     trainInfoT train; // info that a branch must keep for future training
-} DirPredResult#(type trainInfoT) deriving(Bits, Eq, FShow);
+    specInfoT spec;
+} DirPredResult#(type trainInfoT, type specInfoT) deriving(Bits, Eq, FShow);
 
-interface DirPred#(type trainInfoT);
-    method ActionValue#(DirPredResult#(trainInfoT)) pred;
+interface DirPred#(type trainInfoT, type specInfoT);
+    method ActionValue#(DirPredResult#(trainInfoT, specInfoT)) pred;
 endinterface
 
-interface DirPredictor#(type trainInfoT);
+interface DirPredictor#(type trainInfoT, type specInfoT);
     method Action nextPc(Addr nextPc);
-    interface Vector#(SupSize, DirPred#(trainInfoT)) pred;
+    method Action specRecover(specInfoT specInfo, Bool taken);
+    interface Vector#(SupSize, DirPred#(trainInfoT, specInfoT)) pred;
     method Action update(Bool taken, trainInfoT train, Bool mispred);
     method Action flush;
     method Bool flush_done;

--- a/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
@@ -37,6 +37,7 @@ import TourPredSecure::*;
 import TageTest::*;
 
 export DirPredTrainInfo(..);
+export DirPredSpecInfo(..);
 export mkDirPredictor;
 
 `ifdef DIR_PRED_BHT
@@ -56,10 +57,11 @@ typedef BimodalTrainInfo DirPredTrainInfo;
 `endif
 `ifdef DIR_PRED_TAGETEST
 typedef TageTestTrainInfo DirPredTrainInfo;
+typedef TageTestSpecInfo DirPredSpecInfo;
 `endif
 
 (* synthesize *)
-module mkDirPredictor(DirPredictor#(DirPredTrainInfo));
+module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo));
 `ifdef DIR_PRED_BHT
 `ifdef SECURITY
     staticAssert(False, "BHT with flush methods is not implemented");

--- a/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
@@ -51,6 +51,7 @@ typedef GShareTrainInfo DirPredTrainInfo;
 `endif
 `ifdef DIR_PRED_TOUR
 typedef TourTrainInfo DirPredTrainInfo;
+typedef TourPredSpecInfo DirPredSpecInfo;
 `endif
 `ifdef DIR_PRED_BIMODAL
 typedef BimodalTrainInfo DirPredTrainInfo;

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -221,6 +221,7 @@ module mkSpecFifoCF#(
     FShow#(t)
 );
     // correct spec is always the last
+
     Integer sbCorrectSpecPort = valueof(sbPortNum) - 1;
 
     Ehr#(3, Vector#(size, Bool))             valid    <- mkEhr(replicate(False));
@@ -238,11 +239,12 @@ module mkSpecFifoCF#(
         return p == fromInteger(valueOf(size) - 1) ? 0 : p + 1;
     endfunction
 
-    Bool empty_for_canon = all( \== (False) , valid[0] );
+    Bool empty_for_canon = all( \== (False) , valid[1] );
     rule canon_deqP(!valid[1][deqP] && (enqP != deqP || !empty_for_canon));
         // element at deqP was killed, so increment deqP
         deqP <= getNextPtr(deqP);
     endrule
+    
 
     (* fire_when_enabled, no_implicit_conditions *)
     rule canon_speculation;
@@ -516,6 +518,7 @@ module mkSpecFifo_SB_enq_deq_C_enq_deq(
     let m <- mkSpecFifo(sched, True);
     return m;
 endmodule
+
 
 module mkSpecFifoUG#(Bool lazyEnq)(
     SpecFifo#(size, t, validPortNum, sbPortNum)

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -221,7 +221,6 @@ module mkSpecFifoCF#(
     FShow#(t)
 );
     // correct spec is always the last
-
     Integer sbCorrectSpecPort = valueof(sbPortNum) - 1;
 
     Ehr#(3, Vector#(size, Bool))             valid    <- mkEhr(replicate(False));
@@ -244,7 +243,6 @@ module mkSpecFifoCF#(
         // element at deqP was killed, so increment deqP
         deqP <= getNextPtr(deqP);
     endrule
-    
 
     (* fire_when_enabled, no_implicit_conditions *)
     rule canon_speculation;
@@ -518,7 +516,6 @@ module mkSpecFifo_SB_enq_deq_C_enq_deq(
     let m <- mkSpecFifo(sched, True);
     return m;
 endmodule
-
 
 module mkSpecFifoUG#(Bool lazyEnq)(
     SpecFifo#(size, t, validPortNum, sbPortNum)

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -36,7 +36,7 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo));
         predIfc[i] = (interface DirPred;
         
         method ActionValue#(DirPredResult#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo)) pred;
-            $display("Cycle %0d, TAGETEST, Prediction on %x\n", cur_cycle, currentPc);
+            //$display("Cycle %0d, TAGETEST, Prediction on %x\n", cur_cycle, currentPc);
             let result <- tage.dirPredInterface.pred[i].pred;
             return result;
         endmethod

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -27,6 +27,7 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo));
     Tage#(7) tage <- mkTage;
     Reg#(UInt#(64)) predCount <- mkReg(0);
     Reg#(UInt#(64)) misPredCount <- mkReg(0);
+    Reg#(Addr) currentPc <- mkRegU;
 
 
     
@@ -35,6 +36,7 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo));
         predIfc[i] = (interface DirPred;
         
         method ActionValue#(DirPredResult#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo)) pred;
+            $display("Cycle %0d, TAGETEST, Prediction on %x\n", cur_cycle, currentPc);
             let result <- tage.dirPredInterface.pred[i].pred;
             return result;
         endmethod
@@ -54,6 +56,7 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo));
 
     method Action nextPc(Addr pc);
         tage.dirPredInterface.nextPc(pc);
+        currentPc <= pc;
     endmethod
 
     method Action specRecover(TageSpecInfo specInfo, Bool taken);


### PR DESCRIPTION
- Do something very similar as to CHERI Tooba using a specFIFO for updates
- Recover histories immediately in the ALU
   - Only an issue if wrongly speculated misprediction allowed in AluFin after misprediction before it

Had to change SpecFIFO because of difference in EHRs, (would it be better to change EHR to match CHERI EHR?)
  - Also was global_incorrectSpec_ff wrong before?