### PR TITLE
Not working + not utilizing fast predictions properly

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -63,6 +63,11 @@ typedef struct {
 } DirPredResult#(type trainInfoT) deriving(Bits, Eq, FShow);
 
 typedef struct {
+  Bool taken;
+  fastTrainInfoT train;
+} FastPredictResult#(type fastTrainInfoT) deriving(Bits, Eq, FShow);
+
+typedef struct {
     DirPredResult#(trainInfoT) result;
     Epoch main_epoch;
     Bool decode_epoch;
@@ -70,23 +75,25 @@ typedef struct {
 
 typedef struct {
   Addr pc;
+  FastPredictResult#(fastTrainInfoT) fastTrainInfo;
   Epoch main_epoch;
   Bool decode_epoch;
-} PredIn deriving(Bits, Eq, FShow);
+} PredIn#(type fastTrainInfoT) deriving(Bits, Eq, FShow);
 
 
 interface DirPred#(type trainInfoT);
   method ActionValue#(Maybe#(DirPredResult#(trainInfoT))) pred;
 endinterface
 
-interface DirPredictor#(type trainInfoT, type specInfoT);
-    method Action nextPc(Vector#(SupSize,Maybe#(PredIn)) next);
+interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT);
+    method Action nextPc(Vector#(SupSize,Maybe#(PredIn#(fastTrainInfoT))) next);
     method Action specRecover(specInfoT specInfo, Bool taken, Bool nonBranch);
     //interface Vector#(SupSize, DirPred#(trainInfoT, specInfoT)) pred;
     method Action update(Bool taken, trainInfoT train, Bool mispred);
     
     // Does it need to be tagged. Should always be able to provide a result when called
     interface Vector#(SupSize, DirPred#(trainInfoT)) pred;
+    method ActionValue#(Vector#(SupSizeX2, FastPredictResult#(fastTrainInfoT))) fastPred(Addr pc); // No training
     
     method Action confirmPred(Bit#(SupSize) results, SupCnt count); // By decode stage, for speculative history and end_pointer update
     

--- a/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
@@ -38,13 +38,16 @@ import GSharePred::*;
 import TourPred::*;
 
 import TourPredSecure::*;
+import TourPredStaged::*; FOR NOW
 */
 import TageTest::*;
 
-import TourPredStaged::*;
+
 
 export DirPredTrainInfo(..);
 export DirPredSpecInfo(..);
+export DirPredFastTrainInfo(..);
+export DirPredIn;
 export mkDirPredictor;
 
 `ifdef DIR_PRED_BHT
@@ -70,10 +73,12 @@ typedef BimodalTrainInfo DirPredTrainInfo;
 `ifdef DIR_PRED_TAGETEST
 typedef TageTestTrainInfo DirPredTrainInfo;
 typedef TageTestSpecInfo DirPredSpecInfo;
+typedef TageTestFastTrainInfo DirPredFastTrainInfo;
 `endif
 
+typedef PredIn#(DirPredFastTrainInfo) DirPredIn;
 //(* synthesize *)
-module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo));
+module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo, DirPredFastTrainInfo));
 `ifdef DIR_PRED_BHT
 `ifdef SECURITY
     staticAssert(False, "BHT with flush methods is not implemented");

--- a/src_Core/RISCY_OOO/procs/lib/Tage.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Tage.bsv
@@ -436,11 +436,13 @@ module mkTage(Tage#(numTables)) provisos(
     endrule
 
     for (Integer i = 0; i < valueOf(SupSize); i = i + 1) begin
+        (* no_implicit_conditions, fire_when_enabled *)
         rule predStageOne(predIn[i].wget matches tagged Valid .in);
             $display("Prediction on %x\n", in.pc);
             TageTrainInfo#(numTables) ret = unpack(0);
-            // Addr pc = offsetPc(in.pc, i);
+            
             Addr pc = in.pc;
+
 
             `ifdef DEBUG_TAGETEST
                 $display("TAGETEST LFSR %d\n", lfsr.value);
@@ -530,7 +532,7 @@ module mkTage(Tage#(numTables)) provisos(
         Bit#(TAdd#(TLog#(SupSize),1)) count = 0;
         for (Integer i = 0; i < valueOf(SupSize); i = i + 1) begin
             if(pred1ToPred2[i] matches tagged Valid .in) begin
-                $display("Predict2 detected %x %d", results[i].result.pc, i);
+                $display("Predict2 detected %x %d %d", results[i].result.pc, i, cur_cycle);
                 results[count] = in;
                 count = count + 1;
             end

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -14,6 +14,7 @@ import Cur_Cycle :: *;
 
 export TageTestTrainInfo;
 export TageTestSpecInfo;
+export TageTestFastTrainInfo;
 export Entry;
 export PCIndex;
 export PCIndexSz;
@@ -22,8 +23,9 @@ export mkTageTest;
 `define NUM_TABLES 7
 typedef TageTrainInfo#(`NUM_TABLES) TageTestTrainInfo;
 typedef TageSpecInfo TageTestSpecInfo;
+typedef TageFastTrainInfo TageTestFastTrainInfo;
 
-module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo));
+module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;
     Reg#(UInt#(64)) predCount <- mkReg(0);
@@ -45,8 +47,13 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo));
         tage.dirPredInterface.confirmPred(results, count);
     endmethod
 
-    method Action nextPc(Vector#(SupSize,Maybe#(PredIn)) next);
+    method Action nextPc(Vector#(SupSize,Maybe#(PredIn#(TageFastTrainInfo))) next);
         tage.dirPredInterface.nextPc(next);
+    endmethod
+
+    method ActionValue#(Vector#(SupSizeX2, FastPredictResult#(TageFastTrainInfo))) fastPred(Addr pc); // No training
+        let a <- tage.dirPredInterface.fastPred(pc);
+        return a;
     endmethod
 
     method Action specRecover(TageSpecInfo specInfo, Bool taken, Bool nonBranch);


### PR DESCRIPTION
Fast predictions by the main predictor are used by the front end instead of the BTB predictions. This hopefully reduces the first level of mispeculation. Any training data from fast predictions is sent to the predictor as well to mitigate structural hazards (fast predictions at the same time as an actual prediction)

- This also facilitiates another optimisation I will do to allow speculative history on two levels of speculation rather than just one. So the first stage of prediction will have the most recent speculative history. This is in #11 

**There were also some bugs pointed out by these changes with the front end. 'feed_predictors' makes sure the prediction pipeline is always fed if there are predictions in the queue even if F1 doesn't get called**. Not previously captured in testing before, most likely due to bad luck.

(builds/staged2_tage1, probably)