### PR TITLE
Early speculative history update (by fast predictions)

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -102,6 +102,7 @@ interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT);
     interface Vector#(SupSize, SupFifoDeq#(GuardedResult#(trainInfoT))) clearIfc;
 
     method specInfoT getSpec(SupCnt i);
+    method Action updateSpec(Bit#(TAdd#(TLog#(SupSizeX2),1)) i);
 
     method Action flush;
     method Bool flush_done;

--- a/src_Core/RISCY_OOO/procs/lib/CircBuff.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/CircBuff.bsv
@@ -14,6 +14,7 @@ endinterface
 
 interface CircBuff#(numeric type size, type t);
     interface Vector#(SupSize, CircBuffAssign#(size)) specAssign;
+    method Action specUpdate(Bit#(TAdd#(TLog#(SupSizeX2),1)) count);
 
     method CircBuffIndex#(size) specAssignUnconfirmed(SupCnt count);
     method Action specAssignConfirmed(SupCnt count);
@@ -59,6 +60,13 @@ module mkCircBuff(CircBuff#(size, t)) provisos(Bits#(t, a__));
         endinterface);
     end
     interface specAssign = assignIfc;
+
+    method Action specUpdate(Bit#(TAdd#(TLog#(SupSizeX2),1)) count);
+        CircBuffIndex#(size) index = endSpecLast;
+        for(Integer i = 0; fromInteger(i) < count; i = i +1)
+            index = nextIndex(index);
+        endSpec[0] <= index;
+    endmethod
 
     method CircBuffIndex#(size) specAssignUnconfirmed(SupCnt count);
         CircBuffIndex#(size) index = endSpecLast;

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -64,6 +64,10 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageT
         return tage.dirPredInterface.getSpec(i);
     endmethod
 
+    method Action updateSpec(Bit#(TAdd#(TLog#(SupSizeX2),1)) i);
+        tage.dirPredInterface.updateSpec(i);
+    endmethod
+
     method flush = noAction;
     method flush_done = True;
 endmodule


### PR DESCRIPTION
As facilitated by PR #10 (Fast predictions) could now use fast predictions as early speculative history. Not just that, predictions in the same cycle now include eachothers history, though it is predicted as not taken, which I could change at some point but generally this is accurate enough.

Speculation recovery is needed in the decode stage now as well as at the end of the ALU pipeline. For any branch the fast prediction speculation is replaced by the actual prediction (second level of speculation) if they differ. Any decode redirection not caused by a branch uses the same mechanism as the indirect jump miss recovery in the backend. This is done by, in the front end, assigning the current speculation index each instruction is based on, though this does have an overhead.

Some of the logic for edge cases.
- `rule feedPredictor(!predInput.deqS[0].canDeq || isCurrentPredInput(predInput.deqS[0].first));`, must be able to flush prediction inputs now because we do not want them to contribute to the history, we already know they are mispeculated. However rare, potentially this could lead to a prediction not being served though I haven't yet come across this in testing. Maybe atleast a separate rule to enqueue so predictions do not get lost, doesn't solve timing issue.
-  epoch check in predictor possibly, but this has its own issues. Still rare potential timing issue