### PR TITLE
Staged version of TAGE

### DIFF
--- a/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
@@ -31,6 +31,32 @@ interface RWBramCore#(type addrT, type dataT);
     method Action deqRdResp;
 endinterface
 
+module mkRWBramCoreUGLoaded#(String fileName)(RWBramCore#(addrT, dataT)) provisos(
+    Bits#(addrT, addrSz), Bits#(dataT, dataSz)
+);
+    BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2Load(valueOf(TExp#(addrSz)), False, fileName, False);
+    BRAM_PORT#(addrT, dataT) wrPort = bram.a;
+    BRAM_PORT#(addrT, dataT) rdPort = bram.b;
+
+    method Action wrReq(addrT a, dataT d);
+        wrPort.put(True, a, d);
+    endmethod
+
+    method Action rdReq(addrT a);
+        rdPort.put(False, a, ?);
+    endmethod
+
+    method dataT rdResp;
+        return rdPort.read;
+    endmethod
+
+    method rdRespValid = True;
+
+    method Action deqRdResp;
+        noAction;
+    endmethod
+endmodule
+
 module mkRWBramCore(RWBramCore#(addrT, dataT)) provisos(
     Bits#(addrT, addrSz), Bits#(dataT, dataSz)
 );

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -611,7 +611,7 @@ module mkFetchStage(FetchStage);
     endrule: doFetch2
 
    function Bool isCurrent(Fetch2ToDecode in) = (in.main_epoch == f_main_epoch && in.decode_epoch == decode_epoch[0]);
-   function Bool isCurrentPred(GuardedResult#(DirPredTrainInfo) in) = (in.main_epoch == f_main_epoch && in.decode_epoch == decode_epoch[0]);
+   function Bool isCurrentPred(GuardedResult#(DirPred2toPred3Info) in) = (in.main_epoch == f_main_epoch && in.decode_epoch == decode_epoch[0]);
 
    rule doDecodeFlush(f2d.deqS[0].canDeq && !isCurrent(f2d.deqS[0].first));
       for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1)

--- a/src_Core/RISCY_OOO/procs/lib/BimodalTable.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BimodalTable.bsv
@@ -28,7 +28,7 @@ typedef struct {
 typedef Tuple2#(Bit#(pIndex), Bit#(hIndex)) BimodalInd#(numeric type pIndex, numeric type hIndex);
 
 interface BimodalTable#(numeric type predIndexSize, numeric type hystIndexSize);
-    method BimodalPredictionEntry accessPrediction(Addr pc);
+    method BimodalTableEntry accessPrediction(Addr pc);
     method BimodalInd#(predIndexSize, hystIndexSize) trainingInfo(Addr pc); // To be used in training    
     
     // No need to drag along the indices, as entry will always be the same
@@ -53,8 +53,9 @@ module mkBimodalTable#(String predInitFile, String hystInitFile)(BimodalTable#(p
         return tuple2(truncate(combined), truncate(combined >> valueOf(TSub#(predIndexSize, hystIndexSize))));
     endfunction
 
-    method BimodalPredictionEntry accessPrediction(Addr pc);
-        return predTable.sub(tpl_1(pcToIndex(pc)));
+    method BimodalTableEntry accessPrediction(Addr pc);
+        match {.ind1, .ind2} = pcToIndex(pc);
+        return BimodalTableEntry{pred: predTable.sub(ind1), hyst: hystTable.sub(ind2)};
     endmethod
 
     method BimodalInd#(predIndexSize, hystIndexSize) trainingInfo(Addr pc); // To be used in training    

--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -68,10 +68,10 @@ typedef struct {
 } FastPredictResult#(type fastTrainInfoT) deriving(Bits, Eq, FShow);
 
 typedef struct {
-    DirPredResult#(trainInfoT) result;
+    t result;
     Epoch main_epoch;
     Bool decode_epoch;
-} GuardedResult#(type trainInfoT) deriving(Bits, Eq, FShow);
+} GuardedResult#(type t) deriving(Bits, Eq, FShow);
 
 typedef struct {
   Addr pc;
@@ -80,12 +80,11 @@ typedef struct {
   Bool decode_epoch;
 } PredIn#(type fastTrainInfoT) deriving(Bits, Eq, FShow);
 
-
 interface DirPred#(type trainInfoT);
   method ActionValue#(Maybe#(DirPredResult#(trainInfoT))) pred;
 endinterface
 
-interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT);
+interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT, type pred2toPred3InfoT); //Exposed types
     method Action nextPc(Vector#(SupSize,Maybe#(PredIn#(fastTrainInfoT))) next);
     method Action specRecover(specInfoT specInfo, Bool taken, Bool nonBranch);
     //interface Vector#(SupSize, DirPred#(trainInfoT, specInfoT)) pred;
@@ -97,7 +96,7 @@ interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT);
     
     // Could instead be fully inside the predictor without exposing this interface, but still need to communicate 
     // the current main_epoch and decode.epoch each cycle, also every predictor will need this added logic, sounds like a pain
-    interface Vector#(SupSize, SupFifoDeq#(GuardedResult#(trainInfoT))) clearIfc;
+    interface Vector#(SupSize, SupFifoDeq#(GuardedResult#(pred2toPred3InfoT))) clearIfc;
 
     method specInfoT getSpec(SupCnt i);
     method Action updateSpec(Bit#(TAdd#(TLog#(SupSizeX2),1)) i);

--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -95,8 +95,6 @@ interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT);
     interface Vector#(SupSize, DirPred#(trainInfoT)) pred;
     method ActionValue#(Vector#(SupSizeX2, FastPredictResult#(fastTrainInfoT))) fastPred(Addr pc); // No training
     
-    method Action confirmPred(Bit#(SupSize) results, SupCnt count); // By decode stage, for speculative history and end_pointer update
-    
     // Could instead be fully inside the predictor without exposing this interface, but still need to communicate 
     // the current main_epoch and decode.epoch each cycle, also every predictor will need this added logic, sounds like a pain
     interface Vector#(SupSize, SupFifoDeq#(GuardedResult#(trainInfoT))) clearIfc;

--- a/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
@@ -47,6 +47,7 @@ import TageTest::*;
 export DirPredTrainInfo(..);
 export DirPredSpecInfo(..);
 export DirPredFastTrainInfo(..);
+export DirPred2toPred3Info(..);
 export DirPredIn;
 export mkDirPredictor;
 
@@ -74,11 +75,12 @@ typedef BimodalTrainInfo DirPredTrainInfo;
 typedef TageTestTrainInfo DirPredTrainInfo;
 typedef TageTestSpecInfo DirPredSpecInfo;
 typedef TageTestFastTrainInfo DirPredFastTrainInfo;
+typedef TageTestPred2ToPred3Info DirPred2toPred3Info;
 `endif
 
 typedef PredIn#(DirPredFastTrainInfo) DirPredIn;
 //(* synthesize *)
-module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo, DirPredFastTrainInfo));
+module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo, DirPredFastTrainInfo, DirPred2toPred3Info));
 `ifdef DIR_PRED_BHT
 `ifdef SECURITY
     staticAssert(False, "BHT with flush methods is not implemented");

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -43,9 +43,9 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageT
     interface pred = tage.dirPredInterface.pred;
     interface clearIfc = tage.dirPredInterface.clearIfc;
 
-    method Action confirmPred(Bit#(SupSize) results, SupCnt count);
+    /*method Action confirmPred(Bit#(SupSize) results, SupCnt count);
         tage.dirPredInterface.confirmPred(results, count);
-    endmethod
+    endmethod*/
 
     method Action nextPc(Vector#(SupSize,Maybe#(PredIn#(TageFastTrainInfo))) next);
         tage.dirPredInterface.nextPc(next);

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -15,6 +15,7 @@ import Cur_Cycle :: *;
 export TageTestTrainInfo;
 export TageTestSpecInfo;
 export TageTestFastTrainInfo;
+export TageTestPred2ToPred3Info;
 export Entry;
 export PCIndex;
 export PCIndexSz;
@@ -24,8 +25,9 @@ export mkTageTest;
 typedef TageTrainInfo#(`NUM_TABLES) TageTestTrainInfo;
 typedef TageSpecInfo TageTestSpecInfo;
 typedef TageFastTrainInfo TageTestFastTrainInfo;
+typedef TagePred2ToPred3Data#(`NUM_TABLES) TageTestPred2ToPred3Info;
 
-module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
+module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo, TageTestPred2ToPred3Info));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;
     Reg#(UInt#(64)) predCount <- mkReg(0);

--- a/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
@@ -1,0 +1,224 @@
+import GlobalBranchHistory::*;
+import FoldedHistory::*;
+import BrPred::*;
+import BranchParams::*;
+import ProcTypes::*;
+import Types::*;
+import Util::*;
+import RWBramCore::*;
+
+import RegFile::*;
+import Vector::*;
+
+
+`define MAX_TAGGED 12
+`define MAX_INDEX_SIZE 10
+
+typedef 3 PredCtrSz;
+typedef Bit#(PredCtrSz) PredCtr;
+
+typedef 2 UsefulCtrSz;
+typedef Bit#(UsefulCtrSz) UsefulCtr;
+
+typedef TaggedTableEntry#(`MAX_TAGGED) WrappedEntry;
+
+typedef struct {
+    PredCtr predictionCounter;
+    UsefulCtr usefulCounter;
+    Bit#(tagSize) tag;
+} TaggedTableEntry#(numeric type tagSize) deriving(Bits, Eq, FShow);
+
+typedef struct {
+    PredCtr predictionCounter;
+    Bit#(tagSize) tag;
+} InternalTaggedEntry#(numeric type tagSize) deriving(Bits, Eq, FShow);
+
+typedef enum {
+    INCREMENT,
+    PRESERVE,
+    DECREMENT
+} UsefulCtrUpdate deriving (Bits, Eq, FShow);
+
+typedef enum {
+    BEFORE_RECOVERY,
+    AFTER_RECOVERY
+} HistoryRetrieve deriving (Bits, Eq, FShow);
+
+function Bool takenFromCounter(PredCtr ctr);
+    return unpack(pack(ctr)[valueOf(TSub#(PredCtrSz,1))]);
+endfunction
+
+
+// 100
+// 011
+function Bool weakCounter(PredCtr ctr);
+    return (pack(ctr) == (1 << valueOf(TSub#(PredCtrSz,1)))) || (pack(ctr) == ((1 << valueOf(TSub#(PredCtrSz,1)))-1));
+endfunction
+
+interface TaggedTableRead#(numeric type tagSize, numeric type indexSize);
+    method ActionValue#(Tuple2#(Bit#(`MAX_TAGGED), Bit#(`MAX_INDEX_SIZE))) lookupStart(Addr pc);
+    method TaggedTableEntry#(`MAX_TAGGED) read;
+endinterface
+
+interface TaggedTableBRAM#(numeric type indexSize, numeric type tagSize, numeric type historyLength);
+    
+    //method TaggedTableEntry#(`MAX_TAGGED) access_wrapped_entry(Addr pc, Bit#(indexSize) index);
+
+    interface Vector#(SupSize, TaggedTableRead#(tagSize, indexSize)) taggedTableRead;
+    //method TaggedTableEntry#(`MAX_TAGGED) access_wrapped_entry(Addr pc);
+    method Tuple2#(Bit#(tagSize), Bit#(indexSize)) trainingInfo(Addr pc, HistoryRetrieve recovered); // To be used in training
+
+    method Action updateEntry(Bit#(`MAX_INDEX_SIZE) index, TaggedTableEntry#(`MAX_TAGGED) currentEntry, Bool taken, UsefulCtrUpdate usefulUpdate);        
+    method Action updateHistory(Bit#(SupSize) results, SupCnt count);
+    method Action updateRecovered(Bit#(1) taken);
+    method Action recoverHistory(Bit#(TLog#(MaxSpecSize)) numRecovery);
+    method Action decrementUsefulCounter(Bit#(indexSize) index, UsefulCtr ctr); // Many alternative options here, seperate useful counters?
+    method Action allocateEntry(Bit#(indexSize) index, Bit#(tagSize) tag, Bool taken);
+
+    /// Debug
+    `ifdef DEBUG
+        method Action debugUnsetEntry(Addr pc);
+        method TaggedTableEntry#(tagSize) debugGetEntry(Bit#(indexSize) index);
+    `endif
+
+    `ifdef DEBUG_TAGETEST
+        method Bit#(TAdd#(tagSize, indexSize)) debugGetHistory(HistoryRetrieve hr, Maybe#(Bit#(TLog#(SupSize))) count);
+    `endif
+endinterface
+
+module mkTaggedTableBRAM#(GlobalBranchHistory#(GlobalHistoryLength) global) (TaggedTableBRAM#(indexSize, tagSize, historyLength)) provisos(
+    Add#(a__, indexSize, 64), 
+    Add#(b__, tagSize, 64), 
+    Add#(indexSize, tagSize, foldedSize),
+    Add#(f__, TAdd#(tagSize, indexSize), 64),
+    Add#(d__, tagSize, `MAX_TAGGED),
+    Add#(c__, indexSize, `MAX_INDEX_SIZE));
+    
+    FoldedHistory#(TAdd#(tagSize, indexSize)) folded <- mkFoldedHistory(valueOf(historyLength), global);
+    //RegFile#(Bit#(indexSize), TaggedTableEntry#(tagSize)) tab <- mkRegFileWCFLoad(regInitTaggedTableFilename, 0, maxBound);
+
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUG);
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUG);
+
+    Vector#(SupSize, TaggedTableRead#(tagSize, indexSize)) taggedTableReadIfc;
+//    Reg#(Maybe#(Bit#(indexSize))) decrementReadFrom <- mkDReg(tagged Invalid);
+
+    function Tuple2#(Bit#(tagSize), Bit#(indexSize)) getHistory(HistoryRetrieve hr, Addr pc, Maybe#(Bit#(TLog#(SupSize))) count);
+        Bit#(TAdd#(tagSize, indexSize)) hist = 0;
+        if(hr == AFTER_RECOVERY)
+            hist = folded.recoveredHistory;
+        else if(hr == BEFORE_RECOVERY)
+            if(count matches tagged Valid .num)
+                hist = folded.sameWindowHistory[num].history;
+            else
+                hist = folded.history;
+
+        let combined = (pack(pc) ^ (pack(pc) >> 2) ^ (pack(pc) >> 5)) ^ zeroExtend(hist);
+        
+        let index = combined[valueOf(indexSize)-1:0];
+        let tag = combined[valueOf(tagSize)+valueOf(indexSize)-1:valueOf(indexSize)] ^ truncate(pack(pc));
+        return tuple2(tag, index);
+    endfunction
+
+    for(Integer i = 0; i < valueOf(SupSize); i = i+1) begin
+        taggedTableReadIfc[i] = (interface TaggedTableRead#(tagSize, indexSize);
+            method ActionValue#(Tuple2#(Bit#(`MAX_TAGGED), Bit#(`MAX_INDEX_SIZE))) lookupStart(Addr pc);
+                match {.tag, .index} = getHistory(BEFORE_RECOVERY, pc, tagged Valid fromInteger(i));
+                entryTabs[i].rdReq(index);
+                usefulTabs[i].rdReq(index);
+                return tuple2(zeroExtend(tag), zeroExtend(index));
+            endmethod
+
+            method WrappedEntry read;
+                Maybe#(WrappedEntry) readVal = tagged Invalid;
+                let respEntry = entryTabs[i].rdResp;
+                let respUseful = usefulTabs[i].rdResp;
+                TaggedTableEntry#(`MAX_TAGGED) ret = TaggedTableEntry{tag: zeroExtend(respEntry.tag), predictionCounter: respEntry.predictionCounter, usefulCounter: respUseful};
+                return ret;
+            endmethod
+        endinterface);
+    end
+    interface taggedTableRead = taggedTableReadIfc;
+
+    method Action updateEntry(Bit#(`MAX_INDEX_SIZE) index, TaggedTableEntry#(`MAX_TAGGED) currentEntry, Bool taken, UsefulCtrUpdate usefulUpdate);        
+        TaggedTableEntry#(`MAX_TAGGED) newEntry = currentEntry;
+        let ind = truncate(index);
+        // Update prediction and useful counter
+        newEntry.predictionCounter = boundedUpdate(currentEntry.predictionCounter, taken);
+        if (usefulUpdate != PRESERVE) begin
+            newEntry.usefulCounter = boundedUpdate(currentEntry.usefulCounter, usefulUpdate == INCREMENT);
+        end
+
+        for(Integer i = 0; i < valueOf(SupSize); i = i + 1) begin
+            entryTabs[i].wrReq(ind, InternalTaggedEntry{tag: truncate(newEntry.tag), predictionCounter: newEntry.predictionCounter});
+            usefulTabs[i].wrReq(ind, newEntry.usefulCounter);
+        end
+    endmethod
+
+    // 3 bits 100 011
+    method Action allocateEntry(Bit#(indexSize) index, Bit#(tagSize) tag, Bool taken);
+        Bit#(PredCtrSz) counter_init = 1 << (valueOf(PredCtrSz)-1);
+        if (!taken) begin
+            counter_init = (1 << (valueOf(PredCtrSz)-1))-1;
+        end
+        
+        InternalTaggedEntry#(tagSize) toWrite = InternalTaggedEntry{predictionCounter: counter_init, tag: tag};
+
+        for(Integer i = 0; i < valueOf(SupSize); i = i + 1) begin
+            entryTabs[i].wrReq(index, toWrite);
+            usefulTabs[i].wrReq(index, 0);
+        end
+    endmethod
+
+    method Action decrementUsefulCounter(Bit#(indexSize) index, UsefulCtr usefulCounter);
+        let newUsefulCounter = boundedUpdate(usefulCounter, False);
+        for(Integer i = 0; i < valueOf(SupSize); i = i + 1) begin
+            usefulTabs[i].wrReq(index, newUsefulCounter);
+        end
+    endmethod
+    
+    // ----------------- DEBUG
+    `ifdef DEBUG
+    method TaggedTableEntry#(tagSize) debugGetEntry(Bit#(indexSize) index);
+        return tab.sub(index);
+    endmethod
+
+    method Action debugUnsetEntry(Addr pc);
+        match {.tag, .index} = getHistory(AFTER_RECOVERY, pc, tagged Invalid);
+        tab.upd(index, TaggedTableEntry{tag: 0, predictionCounter:0, usefulCounter:0});
+    endmethod
+    `endif
+
+    `ifdef DEBUG_TAGETEST
+        method Bit#(TAdd#(tagSize, indexSize)) debugGetHistory(HistoryRetrieve hr, Maybe#(Bit#(TLog#(SupSize))) count);
+            Bit#(TAdd#(tagSize, indexSize)) hist = 0;
+            if(hr == AFTER_RECOVERY)
+                hist = folded.recoveredHistory;
+            else if(hr == BEFORE_RECOVERY)
+                if(count matches tagged Valid .num)
+                    hist = folded.sameWindowHistory[num].history;
+                else
+                    hist = folded.history;
+            return hist;
+        endmethod
+    `endif
+    
+    
+    
+    // ----------------- DEBUG
+
+
+
+    method Action updateHistory(Bit#(SupSize) results, SupCnt count) = folded.updateHistory(results, count);
+    method Action updateRecovered(Bit#(1) taken) = folded.updateRecoveredHistory(taken);
+    method Action recoverHistory(Bit#(TLog#(MaxSpecSize)) numRecovery);
+        //sameCycleRecovery.send;
+        folded.recoverFrom[numRecovery].undo;
+    endmethod
+
+  
+    method Tuple2#(Bit#(tagSize), Bit#(indexSize)) trainingInfo(Addr pc, HistoryRetrieve recovered); // To be used in training
+        return getHistory(recovered, pc, tagged Invalid);
+    endmethod
+
+endmodule

--- a/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
@@ -97,8 +97,8 @@ module mkTaggedTableBRAM#(GlobalBranchHistory#(GlobalHistoryLength) global) (Tag
     FoldedHistory#(TAdd#(tagSize, indexSize)) folded <- mkFoldedHistory(valueOf(historyLength), global);
     //RegFile#(Bit#(indexSize), TaggedTableEntry#(tagSize)) tab <- mkRegFileWCFLoad(regInitTaggedTableFilename, 0, maxBound);
 
-    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUG);
-    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUG);
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUGLoaded(regInitTaggedTableFilename));
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUGLoaded(regInitTaggedTableFilename));
 
     Vector#(SupSize, TaggedTableRead#(tagSize, indexSize)) taggedTableReadIfc;
 //    Reg#(Maybe#(Bit#(indexSize))) decrementReadFrom <- mkDReg(tagged Invalid);


### PR DESCRIPTION
- Have to seperate useful counters from the rest of the entry for the decrement. Useful counters are sent across as training data, though this isn't much compared to what is already sent as training data.
- RWBRAMCore with load as well so I can initialise useful counters to 0
- Duplicate tagged tables rather than banking. Could engineer size of the tagged tables